### PR TITLE
Update markdown.ts to remove replace of &lt and &gt with < and >.

### DIFF
--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -30,8 +30,6 @@ export function createMarkdown(useOptions: ResolvedOptions) {
     const h = DomUtils.getOuterHTML(root, { selfClosingTags: true })
       .replace(/"vfm{{/g, '{{')
       .replace(/}}vfm"/g, '}}')
-      .replace(/&lt;/g, '<')
-      .replace(/&gt;/g, '>')
       .replace(/&quot;/g, '"')
       .replace(/&amp;/g, '&')
       // handle notes


### PR DESCRIPTION
By removing the replace this the React output is correct and markdown containing < or > renders correctly.
Addresses https://github.com/geekris1/vite-plugin-react-markdown/issues/2#issue-1832121224